### PR TITLE
Add HTML Exporting

### DIFF
--- a/src/hooks/useSanitizeHTML.tsx
+++ b/src/hooks/useSanitizeHTML.tsx
@@ -20,6 +20,7 @@ export const useSanitizeHtml = () => {
       "ol",
       "li",
       "blockquote",
+      "pre",
       "code",
       "hr",
       "table",

--- a/src/pages/MarkdownPreviewer/MarkdownPreviewer.css
+++ b/src/pages/MarkdownPreviewer/MarkdownPreviewer.css
@@ -1,6 +1,6 @@
 .markdown-previewer {
   padding: 24px;
-  
+
   display: flex;
   flex-direction: row;
   flex: 1;
@@ -16,7 +16,7 @@
   gap: 8px;
 }
 
-.markdown-previewer-editor-label, .markdown-previewer-preview-label {
+.markdown-previewer-editor-label, .markdown-previewer-preview-header-label {
   font-weight: 600;
   color: var(--text-primary);
 }
@@ -50,4 +50,21 @@
   border: 2px solid var(--secondary);
   
   overflow: auto;
+}
+
+.markdown-previewer-preview-header {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+}
+
+.markdown-previewer-preview-header-button {
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--text-primary);
+  background-color: var(--primary);
+  border: 2px solid var(--secondary);
+  border-radius: 4px;
+  
+  cursor: pointer;
 }

--- a/src/pages/MarkdownPreviewer/MarkdownPreviewer.tsx
+++ b/src/pages/MarkdownPreviewer/MarkdownPreviewer.tsx
@@ -9,6 +9,21 @@ export const MarkdownPreviewer = () => {
   const debouncedInputText = useDebounce(inputText, 500);
   const { htmlMarkdown } = useMarked({ inputText: debouncedInputText });
 
+  const downloadMarkdownHtml = () => {
+    const element = document.createElement("a");
+    const file = new Blob([htmlMarkdown.__html], { type: "text/html" });
+
+    element.href = URL.createObjectURL(file);
+    element.download = "markdown.html";
+
+    document.body.appendChild(element);
+
+    element.click();
+
+    URL.revokeObjectURL(element.href);
+    document.body.removeChild(element);
+  };
+
   return (
     <div className="markdown-previewer">
       <div className="markdown-previewer-editor">
@@ -22,7 +37,17 @@ export const MarkdownPreviewer = () => {
         />
       </div>
       <div className="markdown-previewer-preview">
-        <div className="markdown-previewer-preview-label">Preview:</div>
+        <div className="markdown-previewer-preview-header">
+          <div className="markdown-previewer-preview-header-label">
+            Preview:
+          </div>
+          <button
+            className="markdown-previewer-preview-header-button download"
+            onClick={downloadMarkdownHtml}
+          >
+            Export
+          </button>
+        </div>
         <div
           className="markdown-previewer-preview-html"
           dangerouslySetInnerHTML={htmlMarkdown}


### PR DESCRIPTION
Changes:
- Fixed newlines in codeblocks
- Added button to download the markdown product html:
![image](https://github.com/ArturoAHR/markdown-previewer/assets/54607567/b8809f7c-d437-47e5-af00-ff9c55e87759)
